### PR TITLE
Update Dockerfile to use latest version of golang

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4 AS builder
+FROM golang:latest AS builder
 
 ARG TARGETARCH
 ARG VERSION


### PR DESCRIPTION
to fix [CVE-2023-45283⁠](https://scout.docker.com/v/CVE-2023-45283)