### PR TITLE
fix: make sure the AppName is a file or dir name

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -178,7 +179,8 @@ func taskReport(r opensca.TaskResult) format.Report {
 
 	report := format.Report{}
 	report.TaskInfo.ToolVersion = version
-	report.TaskInfo.AppName = path
+	// make app name as file or dir name
+	report.TaskInfo.AppName = filepath.Base(filepath.Clean(path))
 	report.TaskInfo.Size = r.Size
 
 	if r.Error != nil {


### PR DESCRIPTION
Make the report and the task list of OpenSCA SaaS appear more organized.
<img width="332" alt="image" src="https://github.com/XmirrorSecurity/OpenSCA-cli/assets/53457978/6acdc46b-7254-45e7-8c8e-a19340738c67">
