### PR TITLE
调整仅保留漏洞组件生效范围

### DIFF
--- a/main.go
+++ b/main.go
@@ -126,7 +126,7 @@ func args() {
 
 	logs.CreateLog(config.Conf().LogFile)
 
-	logs.Infof("opensca-cli version: %s", version)
+	logs.Infof("nsca-xcheck-cli version: %s", version)
 	logs.Infof("use config: %s", cfgf)
 
 	if login {
@@ -249,7 +249,7 @@ func taskReport(r opensca.TaskResult) format.Report {
 	}
 
 	// 仅保留漏洞组件
-	if optional.VulnOnly {
+	/*if optional.VulnOnly {
 		var deps []*detail.DepDetailGraph
 		report.ForEach(func(n *detail.DepDetailGraph) bool {
 			if len(n.Vulnerabilities) > 0 {
@@ -261,7 +261,7 @@ func taskReport(r opensca.TaskResult) format.Report {
 			d.Children = nil
 		}
 		report.DepDetailGraph = &detail.DepDetailGraph{Children: deps}
-	}
+	}*/
 
 	end := time.Now()
 	report.TaskInfo.StartTime = r.Start.Format("2006-01-02 15:04:05")


### PR DESCRIPTION
调整仅保留漏洞组件生效范围为跟漏洞相关的html和json格式，其他检测报告格式以及SBOM清单格式保留完整数据