### PR TITLE
Revert "update: gradle scan dep exists"

### DIFF
--- a/opensca/sca/groovy/gradle.go
+++ b/opensca/sca/groovy/gradle.go
@@ -170,9 +170,7 @@ func GradleTree(ctx context.Context, dir *model.File) []*model.DepGraph {
 				if dep == nil {
 					continue
 				}
-				if dep.Expand != nil {
-					dep.Expand = c
-				}
+				dep.Expand = c
 				n.AppendChild(dep)
 			}
 			return true


### PR DESCRIPTION
This reverts commit c618285600c2196844143bacdc674c31ebffc837.
nil pointer panic.