### PR TITLE
chore: remove unused min func

### DIFF
--- a/opensca/sca/java/xml/typeinfo.go
+++ b/opensca/sca/java/xml/typeinfo.go
@@ -257,13 +257,6 @@ func lookupXMLName(typ reflect.Type) (xmlname *fieldInfo) {
 	return nil
 }
 
-func min(a, b int) int {
-	if a <= b {
-		return a
-	}
-	return b
-}
-
 // addFieldInfo adds finfo to tinfo.fields if there are no
 // conflicts, or if conflicts arise from previous fields that were
 // obtained from deeper embedded structures than finfo. In the latter


### PR DESCRIPTION
Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 