### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cmd/detail/cmp.go
+++ b/cmd/detail/cmp.go
@@ -275,13 +275,13 @@ func (v *Version) Ok() bool {
 // inRangeInterval 判断一个版本是否在一个版本范围内
 func inRangeInterval(ver *Version, interval string) bool {
 	// 遍历所有范围
-	for _, interval := range strings.Split(interval, "||") {
+	for interval := range strings.SplitSeq(interval, "||") {
 		if len(interval) < 2 {
 			continue
 		}
 		// 集合形式
 		if interval[0] == '{' && interval[len(interval)-1] == '}' {
-			for _, v := range strings.Split(strings.Trim(interval, "{}"), ",") {
+			for v := range strings.SplitSeq(strings.Trim(interval, "{}"), ",") {
 				if newVersion(v).Equal(ver) {
 					return true
 				}

--- a/cmd/format/save.go
+++ b/cmd/format/save.go
@@ -34,7 +34,7 @@ type TaskInfo struct {
 }
 
 func Save(report Report, output string) {
-	for _, out := range strings.Split(output, ",") {
+	for out := range strings.SplitSeq(output, ",") {
 		logs.Infof("result save to %s", out)
 		switch filepath.Ext(out) {
 		case ".html":

--- a/opensca/sca/groovy/variable.go
+++ b/opensca/sca/groovy/variable.go
@@ -83,7 +83,7 @@ func (v Variable) Scan(file *model.File) {
 		if object == "" {
 			continue
 		}
-		for _, line := range strings.Split(text[bi[1]:end], "\n") {
+		for line := range strings.SplitSeq(text[bi[1]:end], "\n") {
 			match := varReg.FindStringSubmatch(line)
 			if len(match) == 3 {
 				if object == "ext" {

--- a/opensca/sca/javascript/yarn.go
+++ b/opensca/sca/javascript/yarn.go
@@ -36,7 +36,7 @@ func ParseYarnLock(file *model.File) map[string]*YarnLock {
 
 		if !strings.HasPrefix(line, " ") && strings.HasSuffix(line, ":") {
 			lastDep = &YarnLock{Dependencies: map[string]string{}}
-			for _, tag := range strings.Split(line, ",") {
+			for tag := range strings.SplitSeq(line, ",") {
 				i := strings.LastIndex(tag, "@")
 				if i == -1 {
 					logs.Warnf("parse file %s line: %s fail", file.Relpath(), line)

--- a/opensca/sca/php/composer.go
+++ b/opensca/sca/php/composer.go
@@ -234,7 +234,7 @@ func FindMaxVersion(version string, versions []string) string {
 		s = strings.TrimLeft(strings.TrimSpace(s), "vV")
 		// 将 ~x[.x](php范围约束) 替换为 ^x[.x](semver范围约束)
 		var fix []string
-		for _, sub := range strings.Split(s, ",") {
+		for sub := range strings.SplitSeq(s, ",") {
 			if strings.Contains(sub, "~") && strings.Count(sub, ".") < 2 {
 				sub = strings.ReplaceAll(sub, "~", "^")
 			}
@@ -243,7 +243,7 @@ func FindMaxVersion(version string, versions []string) string {
 		return strings.Join(fix, ",")
 	}
 	var cs []*semver.Constraints
-	for _, v := range strings.Split(version, "|") {
+	for v := range strings.SplitSeq(version, "|") {
 		c, err := semver.NewConstraint(fix(v))
 		if err == nil {
 			cs = append(cs, c)

--- a/opensca/sca/php/sca.go
+++ b/opensca/sca/php/sca.go
@@ -56,7 +56,7 @@ loop:
 		}
 
 		// vendor中的composer.json没有对应lock则不做处理
-		for _, dir := range strings.Split(dir, "/") {
+		for dir := range strings.SplitSeq(dir, "/") {
 			if strings.EqualFold(dir, "vendor") {
 				continue loop
 			}


### PR DESCRIPTION
strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901